### PR TITLE
Feat: add "--cwd" arg to start command + some CLI args refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
 			"version": "1.3.3",
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/claude-code": "^1.0.77",
-				"@anthropic-ai/sdk": "^0.60.0",
 				"@modelcontextprotocol/sdk": "^1.17.2",
 				"@xterm/headless": "^5.5.0",
 				"chalk": "^5.5.0",
@@ -21,6 +19,8 @@
 				"terminalcp": "dist/index.js"
 			},
 			"devDependencies": {
+				"@anthropic-ai/claude-code": "^1.0.77",
+				"@anthropic-ai/sdk": "^0.60.0",
 				"@biomejs/biome": "^2.1.4",
 				"@types/node": "^22.10.5",
 				"husky": "^9.1.7",
@@ -35,6 +35,7 @@
 			"version": "1.0.77",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.77.tgz",
 			"integrity": "sha512-P4jQ9bd9DEcgQUXb94gh8h7bnconmS2qE3eGUHyxNAi8fhSDqA038fmduCKZ/0wCVGPaldYoFIaO35M/ChRtGA==",
+			"dev": true,
 			"license": "SEE LICENSE IN README.md",
 			"bin": {
 				"claude": "cli.js"
@@ -55,6 +56,7 @@
 			"version": "0.60.0",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.60.0.tgz",
 			"integrity": "sha512-9zu/TXaUy8BZhXedDtt1wT3H4LOlpKDO1/ftiFpeR3N1PCr3KJFKkxxlQWWt1NNp08xSwUNJ3JNY8yhl8av6eQ==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"anthropic-ai-sdk": "bin/cli"
@@ -672,6 +674,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -694,6 +697,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -716,6 +720,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -732,6 +737,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -748,6 +754,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -764,6 +771,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -780,6 +788,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -796,6 +805,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -818,6 +828,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -840,6 +851,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -862,6 +874,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
 		"@types/node": "^22.10.5",
 		"husky": "^9.1.7",
 		"tsx": "^4.20.3",
-		"typescript": "^5.9.2"
+		"typescript": "^5.9.2",
+		"@anthropic-ai/claude-code": "^1.0.77",
+		"@anthropic-ai/sdk": "^0.60.0"
 	},
 	"types": "./dist/index.d.ts",
 	"dependencies": {
-		"@anthropic-ai/claude-code": "^1.0.77",
-		"@anthropic-ai/sdk": "^0.60.0",
 		"@modelcontextprotocol/sdk": "^1.17.2",
 		"@xterm/headless": "^5.5.0",
 		"chalk": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"prepublishOnly": "npm run clean && npm run build",
 		"check": "biome check --write . && tsc --project tsconfig.check.json",
 		"prepare": "husky",
-		"test": "tsx --test --test-concurrency=1 test/**/*.test.ts"
+		"test": "tsx --test --test-concurrency=1 test/**/*.test.ts",
+		"install-global": "npm install -g ."
 	},
 	"files": [
 		"dist/**/*",

--- a/src/cli-parser.ts
+++ b/src/cli-parser.ts
@@ -1,0 +1,241 @@
+// CLI argument parsing for terminalcp
+
+export interface ParsedCommand {
+	command: string;
+	args: Record<string, any>;
+	flags: Record<string, string | boolean>;
+}
+
+export interface ParseError {
+	error: string;
+	usage?: string;
+}
+
+export type ParseResult = ParsedCommand | ParseError;
+
+function isError(result: ParseResult): result is ParseError {
+	return "error" in result;
+}
+
+export function parseArgs(args: string[]): ParseResult {
+	if (args.length === 0) {
+		return { error: "No command provided" };
+	}
+
+	const [commandName, ...rest] = args;
+
+	switch (commandName) {
+		case "start":
+			return parseStartCommand(rest);
+		case "stop":
+			return parseStopCommand(rest);
+		case "list":
+		case "ls":
+			return { command: "list", args: {}, flags: {} };
+		case "attach":
+			return parseAttachCommand(rest);
+		case "stdout":
+			return parseStdoutCommand(rest);
+		case "stream":
+			return parseStreamCommand(rest);
+		case "stdin":
+			return parseStdinCommand(rest);
+		case "resize":
+			return parseResizeCommand(rest);
+		case "term-size":
+			return parseTermSizeCommand(rest);
+		case "version":
+			return { command: "version", args: {}, flags: {} };
+		case "kill-server":
+			return { command: "kill-server", args: {}, flags: {} };
+		case "--mcp":
+			return { command: "mcp", args: {}, flags: {} };
+		case "--server":
+			return { command: "server", args: {}, flags: {} };
+		default:
+			return {
+				error: `Unknown command: ${commandName}`,
+				usage: "Run 'terminalcp' without arguments to see help",
+			};
+	}
+}
+
+function parseStartCommand(args: string[]): ParseResult {
+	if (args.length < 2) {
+		return {
+			error: "start command requires session-id and command",
+			usage: "terminalcp start <session-id> <command> [args...] [--cwd <directory>]",
+		};
+	}
+
+	let sessionId: string | undefined;
+	let cwd: string | undefined;
+	const commandArgs: string[] = [];
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--cwd") {
+			if (i + 1 >= args.length) {
+				return {
+					error: "--cwd requires a directory path",
+					usage: "terminalcp start <session-id> <command> [args...] [--cwd <directory>]",
+				};
+			}
+			cwd = args[i + 1];
+			i++; // Skip the next argument since it's the cwd value
+		} else if (!sessionId) {
+			sessionId = arg;
+		} else {
+			commandArgs.push(arg);
+		}
+	}
+
+	if (!sessionId || commandArgs.length === 0) {
+		return {
+			error: "Missing required arguments",
+			usage: "terminalcp start <session-id> <command> [args...] [--cwd <directory>]",
+		};
+	}
+
+	return {
+		command: "start",
+		args: {
+			sessionId,
+			command: commandArgs.join(" "),
+		},
+		flags: cwd ? { cwd } : {},
+	};
+}
+
+function parseStopCommand(args: string[]): ParseResult {
+	return {
+		command: "stop",
+		args: {
+			sessionId: args[0], // Optional
+		},
+		flags: {},
+	};
+}
+
+function parseAttachCommand(args: string[]): ParseResult {
+	if (args.length < 1) {
+		return {
+			error: "attach command requires session-id",
+			usage: "terminalcp attach <id>",
+		};
+	}
+
+	return {
+		command: "attach",
+		args: { sessionId: args[0] },
+		flags: {},
+	};
+}
+
+function parseStdoutCommand(args: string[]): ParseResult {
+	if (args.length < 1) {
+		return {
+			error: "stdout command requires session-id",
+			usage: "terminalcp stdout <id> [lines]",
+		};
+	}
+
+	return {
+		command: "stdout",
+		args: {
+			sessionId: args[0],
+			lines: args[1] ? parseInt(args[1]) : undefined,
+		},
+		flags: {},
+	};
+}
+
+function parseStreamCommand(args: string[]): ParseResult {
+	if (args.length < 1) {
+		return {
+			error: "stream command requires session-id",
+			usage: "terminalcp stream <id> [--since-last] [--with-ansi]",
+		};
+	}
+
+	const sessionId = args[0];
+	const flags: Record<string, boolean> = {};
+
+	for (let i = 1; i < args.length; i++) {
+		if (args[i] === "--since-last") {
+			flags.sinceLast = true;
+		} else if (args[i] === "--with-ansi") {
+			flags.withAnsi = true;
+		}
+	}
+
+	return {
+		command: "stream",
+		args: { sessionId },
+		flags,
+	};
+}
+
+function parseStdinCommand(args: string[]): ParseResult {
+	if (args.length < 2) {
+		return {
+			error: "stdin command requires session-id and data",
+			usage: "terminalcp stdin <id> <text> [text] ...",
+		};
+	}
+
+	return {
+		command: "stdin",
+		args: {
+			sessionId: args[0],
+			data: args.slice(1),
+		},
+		flags: {},
+	};
+}
+
+function parseResizeCommand(args: string[]): ParseResult {
+	if (args.length < 3) {
+		return {
+			error: "resize command requires session-id, cols, and rows",
+			usage: "terminalcp resize <id> <cols> <rows>",
+		};
+	}
+
+	const cols = parseInt(args[1]);
+	const rows = parseInt(args[2]);
+
+	if (isNaN(cols) || isNaN(rows)) {
+		return {
+			error: "cols and rows must be numbers",
+			usage: "terminalcp resize <id> <cols> <rows>",
+		};
+	}
+
+	return {
+		command: "resize",
+		args: {
+			sessionId: args[0],
+			cols,
+			rows,
+		},
+		flags: {},
+	};
+}
+
+function parseTermSizeCommand(args: string[]): ParseResult {
+	if (args.length < 1) {
+		return {
+			error: "term-size command requires session-id",
+			usage: "terminalcp term-size <id>",
+		};
+	}
+
+	return {
+		command: "term-size",
+		args: { sessionId: args[0] },
+		flags: {},
+	};
+}
+
+export { isError };

--- a/test/cli-parser.test.ts
+++ b/test/cli-parser.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { isError, parseArgs } from "../src/cli-parser.js";
+
+describe("CLI Parser", () => {
+	describe("parseArgs", () => {
+		it("should return error for empty args", () => {
+			const result = parseArgs([]);
+			assert.ok(isError(result));
+			assert.strictEqual(result.error, "No command provided");
+		});
+
+		it("should parse simple list command", () => {
+			const result = parseArgs(["list"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "list");
+			assert.deepStrictEqual(result.args, {});
+			assert.deepStrictEqual(result.flags, {});
+		});
+
+		it("should parse ls alias for list", () => {
+			const result = parseArgs(["ls"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "list");
+		});
+
+		it("should return error for unknown command", () => {
+			const result = parseArgs(["unknown"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("Unknown command: unknown"));
+			assert.ok(result.usage?.includes("help"));
+		});
+	});
+
+	describe("start command", () => {
+		it("should parse basic start command", () => {
+			const result = parseArgs(["start", "my-session", "echo", "hello"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "start");
+			assert.strictEqual(result.args.sessionId, "my-session");
+			assert.strictEqual(result.args.command, "echo hello");
+			assert.deepStrictEqual(result.flags, {});
+		});
+
+		it("should parse start command with --cwd flag", () => {
+			const result = parseArgs(["start", "my-session", "pwd", "--cwd", "/tmp"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "start");
+			assert.strictEqual(result.args.sessionId, "my-session");
+			assert.strictEqual(result.args.command, "pwd");
+			assert.strictEqual(result.flags.cwd, "/tmp");
+		});
+
+		it("should parse start command with --cwd in different position", () => {
+			const result = parseArgs(["start", "--cwd", "/home/user", "test", "ls", "-la"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "start");
+			assert.strictEqual(result.args.sessionId, "test");
+			assert.strictEqual(result.args.command, "ls -la");
+			assert.strictEqual(result.flags.cwd, "/home/user");
+		});
+
+		it("should return error when missing session id", () => {
+			const result = parseArgs(["start"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id and command"));
+			assert.ok(result.usage?.includes("terminalcp start"));
+		});
+
+		it("should return error when missing command", () => {
+			const result = parseArgs(["start", "session-only"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id and command"));
+		});
+
+		it("should return error when --cwd has no value", () => {
+			const result = parseArgs(["start", "session", "command", "--cwd"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("--cwd requires a directory path"));
+			assert.ok(result.usage?.includes("--cwd <directory>"));
+		});
+
+		it("should handle complex command with multiple arguments", () => {
+			const result = parseArgs(["start", "build", "npm", "run", "build", "--watch", "--cwd", "/project"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.args.sessionId, "build");
+			assert.strictEqual(result.args.command, "npm run build --watch");
+			assert.strictEqual(result.flags.cwd, "/project");
+		});
+	});
+
+	describe("stop command", () => {
+		it("should parse stop command with session id", () => {
+			const result = parseArgs(["stop", "my-session"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "stop");
+			assert.strictEqual(result.args.sessionId, "my-session");
+		});
+
+		it("should parse stop command without session id", () => {
+			const result = parseArgs(["stop"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "stop");
+			assert.strictEqual(result.args.sessionId, undefined);
+		});
+	});
+
+	describe("attach command", () => {
+		it("should parse attach command", () => {
+			const result = parseArgs(["attach", "session123"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "attach");
+			assert.strictEqual(result.args.sessionId, "session123");
+		});
+
+		it("should return error when missing session id", () => {
+			const result = parseArgs(["attach"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id"));
+		});
+	});
+
+	describe("stdout command", () => {
+		it("should parse stdout command with session id", () => {
+			const result = parseArgs(["stdout", "session1"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "stdout");
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.strictEqual(result.args.lines, undefined);
+		});
+
+		it("should parse stdout command with lines parameter", () => {
+			const result = parseArgs(["stdout", "session1", "50"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.strictEqual(result.args.lines, 50);
+		});
+
+		it("should return error when missing session id", () => {
+			const result = parseArgs(["stdout"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id"));
+		});
+	});
+
+	describe("stream command", () => {
+		it("should parse stream command with flags", () => {
+			const result = parseArgs(["stream", "session1", "--since-last", "--with-ansi"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "stream");
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.strictEqual(result.flags.sinceLast, true);
+			assert.strictEqual(result.flags.withAnsi, true);
+		});
+
+		it("should parse stream command without flags", () => {
+			const result = parseArgs(["stream", "session1"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.deepStrictEqual(result.flags, {});
+		});
+
+		it("should return error when missing session id", () => {
+			const result = parseArgs(["stream"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id"));
+		});
+	});
+
+	describe("stdin command", () => {
+		it("should parse stdin command with data", () => {
+			const result = parseArgs(["stdin", "session1", "hello", "world"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "stdin");
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.deepStrictEqual(result.args.data, ["hello", "world"]);
+		});
+
+		it("should return error when missing data", () => {
+			const result = parseArgs(["stdin", "session1"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id and data"));
+		});
+	});
+
+	describe("resize command", () => {
+		it("should parse resize command", () => {
+			const result = parseArgs(["resize", "session1", "120", "40"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "resize");
+			assert.strictEqual(result.args.sessionId, "session1");
+			assert.strictEqual(result.args.cols, 120);
+			assert.strictEqual(result.args.rows, 40);
+		});
+
+		it("should return error for invalid numbers", () => {
+			const result = parseArgs(["resize", "session1", "abc", "40"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("must be numbers"));
+		});
+
+		it("should return error when missing parameters", () => {
+			const result = parseArgs(["resize", "session1", "120"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id, cols, and rows"));
+		});
+	});
+
+	describe("term-size command", () => {
+		it("should parse term-size command", () => {
+			const result = parseArgs(["term-size", "session1"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "term-size");
+			assert.strictEqual(result.args.sessionId, "session1");
+		});
+
+		it("should return error when missing session id", () => {
+			const result = parseArgs(["term-size"]);
+			assert.ok(isError(result));
+			assert.ok(result.error.includes("requires session-id"));
+		});
+	});
+
+	describe("system commands", () => {
+		it("should parse version command", () => {
+			const result = parseArgs(["version"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "version");
+		});
+
+		it("should parse kill-server command", () => {
+			const result = parseArgs(["kill-server"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "kill-server");
+		});
+
+		it("should parse --mcp flag", () => {
+			const result = parseArgs(["--mcp"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "mcp");
+		});
+
+		it("should parse --server flag", () => {
+			const result = parseArgs(["--server"]);
+			assert.ok(!isError(result));
+			assert.strictEqual(result.command, "server");
+		});
+	});
+});


### PR DESCRIPTION
Hey @badlogic, 

Your blog articles + youtube videos + packages give me a lot of interesting ideas, thanks for this! 

I wanted to use terminalcp as pure CLI (the most simple API) and it is missing the current dir argument for the start command. 
I thought I'm make a small contribution. 

Cheers, 
Roman