### PR TITLE
Bump node-pty to 1.2.0-beta.12 for macOS 26 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@modelcontextprotocol/sdk": "^1.17.2",
 				"@xterm/headless": "^5.5.0",
 				"chalk": "^5.5.0",
-				"node-pty": "^1.0.0",
+				"node-pty": "1.2.0-beta.12",
 				"zod": "^3.25.76"
 			},
 			"bin": {
@@ -1598,12 +1598,6 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nan": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-			"integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-			"license": "MIT"
-		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1613,14 +1607,20 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
+		},
 		"node_modules/node-pty": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
-			"integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+			"integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.17.0"
+				"node-addon-api": "^7.1.0"
 			}
 		},
 		"node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@modelcontextprotocol/sdk": "^1.17.2",
 		"@xterm/headless": "^5.5.0",
 		"chalk": "^5.5.0",
-		"node-pty": "^1.0.0",
+		"node-pty": "1.2.0-beta.12",
 		"zod": "^3.25.76"
 	}
 }


### PR DESCRIPTION
Hey @badlogic 👋

Heavy daily user of terminalcp here — using it as the foundation of an AI-driven workflow on macOS 26 (Tahoe, kernel 25.3.0). Filing four small PRs from a fork I've been running for a few weeks. This one's the gateway.

## Problem

`node-pty 1.1.0` (the version `^1.0.0` resolves to today) returns `posix_spawnp failed` on macOS 26 for **every** start, even for `/bin/zsh` in `/tmp`. I reproduced calling `pty.spawn` directly under both `node v25.9.0` and `bun 1.3.13` — so it's not an MCP/runtime issue, it's the bundled pty binary.

## Fix

Bump `node-pty` from `^1.0.0` to `1.2.0-beta.12`. The `1.2.0-beta` line (active through March 2026, currently `beta.12`) was released specifically to fix Tahoe compat. Pinning to the exact beta avoids surprise upgrades when stable lands.

## Diff

- `package.json` — 1 line
- `package-lock.json` — 22 lines (only node-pty's version + transitive `nan` → `node-addon-api` swap that the new node-pty requires)

## Smoke test

```
node dist/index.js start test "/bin/zsh -c 'echo READY'"
```

Returns `READY` with exit 0 on macOS 26 (was the failure repro before the bump). Existing `tsx --test` suite still passes locally on the relevant files (terminal-manager, key-parser, key-integration, cli-keys — 70/70).

## Upgrading later

When `node-pty 1.2.0` stable lands, this can be moved off the beta pin. Until then, the explicit version pin keeps macOS 26 users on a known-good build.

Three follow-up PRs stack on this one (per-session daemon isolation, log persistence, transparent autospawn). Filed as small/focused PRs intentionally — easier to land or punt individually. Thanks for terminalcp 🙏