### PR TITLE
Per-session daemon isolation + idle timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@modelcontextprotocol/sdk": "^1.17.2",
 				"@xterm/headless": "^5.5.0",
 				"chalk": "^5.5.0",
-				"node-pty": "^1.0.0",
+				"node-pty": "1.2.0-beta.12",
 				"zod": "^3.25.76"
 			},
 			"bin": {
@@ -1598,12 +1598,6 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nan": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-			"integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-			"license": "MIT"
-		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1613,14 +1607,20 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
+		},
 		"node_modules/node-pty": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
-			"integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+			"integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.17.0"
+				"node-addon-api": "^7.1.0"
 			}
 		},
 		"node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@modelcontextprotocol/sdk": "^1.17.2",
 		"@xterm/headless": "^5.5.0",
 		"chalk": "^5.5.0",
-		"node-pty": "^1.0.0",
+		"node-pty": "1.2.0-beta.12",
 		"zod": "^3.25.76"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,28 @@ if (args[0] === "--mcp") {
 			console.error("Failed to start server:", err);
 			process.exit(1);
 		});
+
+		// SIGTERM is what mcp-server.ts sends; without these handlers we'd leave a stale
+		// socket file and skip clearing the idle-check timer.
+		for (const sig of ["SIGINT", "SIGTERM", "SIGQUIT"] as const) {
+			process.on(sig, () => {
+				console.error(`Received ${sig}, shutting down server...`);
+				server.shutdown().catch((err) => {
+					console.error("Shutdown error:", err);
+					process.exit(1);
+				});
+			});
+		}
+		process.on("exit", () => {
+			// Last-ditch socket cleanup if shutdown() didn't get to it.
+			if (fs.existsSync(server.serverSocketPath)) {
+				try {
+					fs.unlinkSync(server.serverSocketPath);
+				} catch {
+					// Already removed — ignore.
+				}
+			}
+		});
 	} else {
 		console.error(`Unknown command: ${args[0]}`);
 		console.error("Run 'terminalcp' without arguments to see help");

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,11 +1,77 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { Args } from "./messages.js";
 import { TerminalClient } from "./terminal-client.js";
 
+async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (fs.existsSync(socketPath)) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`terminalcp daemon socket did not appear at ${socketPath} within ${timeoutMs}ms`);
+}
+
 export async function runMCPServer(): Promise<void> {
-	const serverClient = new TerminalClient();
+	// Per-session isolation: each MCP instance gets its own daemon at a unique socket path
+	// keyed by this process's PID. Closes the door on cross-session interference (one Claude
+	// Code window's cleanup can no longer touch another window's daemon).
+	const socketPath = path.join(os.tmpdir(), `terminalcp-mcp-${process.pid}.sock`);
+
+	// Spawn the dedicated daemon as a non-detached child so its lifecycle is bound to ours.
+	// Three layers of cleanup: (1) explicit kill below on SIGTERM/SIGINT/exit; (2) daemon's
+	// own idle timeout (defaults to 30min, gated on no-running-sessions so long builds aren't
+	// killed); (3) socket path is per-PID, so even leaks don't collide with other sessions.
+	const daemonScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "index.js");
+	const daemon = spawn(process.execPath, [daemonScript, "--server"], {
+		env: {
+			...process.env,
+			TERMINALCP_SOCKET: socketPath,
+		},
+		// stderr inherits so daemon errors surface in the MCP server's stderr (visible in
+		// Claude Code's MCP debug logs). stdin/stdout ignored — the daemon only talks via socket.
+		stdio: ["ignore", "ignore", "inherit"],
+		detached: false,
+	});
+
+	daemon.on("error", (err) => {
+		console.error("[terminalcp] daemon spawn error:", err);
+	});
+	daemon.on("exit", (code, signal) => {
+		console.error(`[terminalcp] daemon exited (code=${code}, signal=${signal})`);
+	});
+
+	// Idempotent kill helper, registered on every shutdown signal we care about.
+	let killed = false;
+	const killDaemon = (): void => {
+		if (killed) return;
+		killed = true;
+		try {
+			daemon.kill("SIGTERM");
+		} catch {
+			// Already dead — ignore.
+		}
+	};
+	process.on("exit", killDaemon);
+
+	// Block until the daemon has bound its socket. Without this, the first TerminalClient
+	// request would race the daemon's `listen()` and trigger the auto-spawn fallback path,
+	// which would create a *second* daemon (orphaned) at the same socket path.
+	try {
+		await waitForSocket(socketPath, 5000);
+	} catch (err) {
+		console.error("[terminalcp] daemon failed to start within 5s:", err);
+		killDaemon();
+		throw err;
+	}
+
+	const serverClient = new TerminalClient(socketPath);
 
 	const server = new Server(
 		{
@@ -179,15 +245,18 @@ Note: Commands run via bash -c. Use absolute paths, not aliases.`,
 		}
 	});
 
-	// Cleanup on exit
-	process.on("SIGINT", async () => {
-		console.error("Shutting down MCP server...");
+	// Cleanup on exit — both signals tear down client and daemon before exiting.
+	const shutdown = (signal: string) => {
+		console.error(`Shutting down MCP server (${signal})...`);
 		serverClient.close();
+		killDaemon();
 		process.exit(0);
-	});
+	};
+	process.on("SIGINT", () => shutdown("SIGINT"));
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
 
 	// Start the server
 	const transport = new StdioServerTransport();
 	await server.connect(transport);
-	console.error("terminalcp MCP server running on stdio");
+	console.error(`terminalcp MCP server running on stdio (daemon socket: ${socketPath})`);
 }

--- a/src/terminal-client.ts
+++ b/src/terminal-client.ts
@@ -33,12 +33,20 @@ const CLIENT_VERSION = packageJson.version;
 
 export class TerminalClient {
 	private socket?: net.Socket;
-	private serverSocketPath = path.join(os.homedir(), ".terminalcp", "server.sock");
+	private serverSocketPath: string;
 	// biome-ignore lint/suspicious/noExplicitAny: Hard to type this without a lot of effort
 	private pendingRequests = new Map<string, { resolve: (result: any) => void; reject: (error: Error) => void }>();
 	private eventHandlers = new Map<string, (event: ServerEvent) => void>();
 	private connected = false;
 	private connectPromise?: Promise<void>;
+
+	constructor(socketPath?: string) {
+		// Explicit arg > env var > historical default. The env var lets a daemon spawned by the
+		// auto-spawn path (which inherits env from the client process) bind to the same per-instance
+		// socket the client is connecting to.
+		this.serverSocketPath =
+			socketPath || process.env.TERMINALCP_SOCKET || path.join(os.homedir(), ".terminalcp", "server.sock");
+	}
 
 	/**
 	 * Connect to the terminal server, starting it if necessary

--- a/src/terminal-server.ts
+++ b/src/terminal-server.ts
@@ -14,15 +14,37 @@ const packageJsonPath = path.join(__dirname, "..", "package.json");
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 const SERVER_VERSION = packageJson.version;
 
+// Default 30 minutes; overridable via TERMINALCP_IDLE_TIMEOUT_MS for testing or tuning.
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+// How often the idle check runs. Overridable via TERMINALCP_IDLE_CHECK_INTERVAL_MS — primarily useful
+// for tests that need to verify cleanup behavior in seconds rather than minutes.
+const DEFAULT_IDLE_CHECK_INTERVAL_MS = 60 * 1000;
+
+function positiveIntEnv(key: string, fallback: number): number {
+	const n = parseInt(process.env[key] ?? "", 10);
+	return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
 export class TerminalServer {
 	private processManager = new TerminalManager();
 	private server?: net.Server;
 	private clients = new Map<string, net.Socket>();
 	private sessionSubscribers = new Map<string, Set<string>>(); // sessionId -> Set<clientId>
-	public readonly serverSocketPath = path.join(os.homedir(), ".terminalcp", "server.sock");
+	public readonly serverSocketPath: string;
 	private clientCounter = 0;
+	private lastActivityAt = Date.now();
+	private idleCheckInterval?: NodeJS.Timeout;
+	private idleTimeoutMs: number;
+	private idleCheckIntervalMs: number;
 
 	constructor() {
+		// Allow per-instance socket path via env (set by mcp-server.ts when spawning a dedicated daemon).
+		// Falls back to the historical shared path so plain `terminalcp --server` and CLI commands still work.
+		this.serverSocketPath = process.env.TERMINALCP_SOCKET || path.join(os.homedir(), ".terminalcp", "server.sock");
+
+		this.idleTimeoutMs = positiveIntEnv("TERMINALCP_IDLE_TIMEOUT_MS", DEFAULT_IDLE_TIMEOUT_MS);
+		this.idleCheckIntervalMs = positiveIntEnv("TERMINALCP_IDLE_CHECK_INTERVAL_MS", DEFAULT_IDLE_CHECK_INTERVAL_MS);
+
 		// Ensure directory exists
 		const dir = path.dirname(this.serverSocketPath);
 		if (!fs.existsSync(dir)) {
@@ -59,15 +81,43 @@ export class TerminalServer {
 				// Set socket permissions to be user-only
 				fs.chmodSync(this.serverSocketPath, 0o600);
 
+				// Start idle-timeout watcher: shut down after N min of no clients AND no running sessions.
+				// The running-sessions guard means a long build keeps the daemon alive even if the
+				// client (e.g. an MCP server) disconnects — important so closing Claude Code mid-build
+				// doesn't kill the build.
+				this.idleCheckInterval = setInterval(() => this.checkIdle(), this.idleCheckIntervalMs);
+
 				resolve();
 			});
 		});
+	}
+
+	private touchActivity(): void {
+		this.lastActivityAt = Date.now();
+	}
+
+	private checkIdle(): void {
+		const idleMs = Date.now() - this.lastActivityAt;
+		const noClients = this.clients.size === 0;
+		const processes = this.processManager.listProcesses();
+		const noRunningSessions = !processes.some((p) => p.running);
+
+		if (noClients && noRunningSessions && idleMs >= this.idleTimeoutMs) {
+			console.error(
+				`[terminalcp] idle for ${Math.floor(idleMs / 1000)}s with no clients and no running sessions — shutting down`,
+			);
+			this.shutdown().catch((err) => {
+				console.error("Idle shutdown error:", err);
+				process.exit(0);
+			});
+		}
 	}
 
 	/**
 	 * Handle a new client connection
 	 */
 	private handleClient(socket: net.Socket): void {
+		this.touchActivity();
 		const clientId = `client-${++this.clientCounter}`;
 		this.clients.set(clientId, socket);
 
@@ -109,6 +159,7 @@ export class TerminalServer {
 	 * Handle a message from a client
 	 */
 	private async handleMessage(clientId: string, message: ServerRequest): Promise<void> {
+		this.touchActivity();
 		const { id: requestId, args } = message;
 
 		if (!requestId || !args.action) {
@@ -344,6 +395,12 @@ export class TerminalServer {
 	 */
 	async shutdown(): Promise<void> {
 		console.error("Shutting down terminal server...");
+
+		// Stop the idle-check timer so the process can exit cleanly.
+		if (this.idleCheckInterval) {
+			clearInterval(this.idleCheckInterval);
+			this.idleCheckInterval = undefined;
+		}
 
 		// Stop all processes
 		await this.processManager.stopAll();


### PR DESCRIPTION
Hey @badlogic 👋

Stacked on #4 (the node-pty bump) — diff in the "Files changed" tab includes that single-line bump because git can't show one without the other when both target `main`. The new content for **this** PR is the second commit, `Add per-session daemon isolation and idle timeout`.

## Problem

The shared `~/.terminalcp/server.sock` singleton means every Claude Code session on the box pokes at the same daemon, and one session's cleanup nukes the others' state.

Concrete pain that motivated this: while debugging the macOS 26 issue (#4) I ran `pkill terminalcp.*--server` to clean up — and instantly killed the daemon a parallel Claude Code session was using mid-Vercel-deploy, blowing away a 4-minute build's output. Same hazard exists for any cross-session `kill-server` or `terminalcp stop`.

## Fix

Each MCP server now spawns its own dedicated daemon at `${TMPDIR}/terminalcp-mcp-${pid}.sock`. The CLI keeps using the historical singleton path (so `terminalcp ls`, `kill-server`, etc. behave identically), but every MCP-spawned daemon is isolated.

The MCP server binds its daemon's lifecycle to its own via `SIGTERM`/`SIGINT`/`exit` handlers. SIGKILL skips those — for that case, a per-daemon idle-timeout watcher reaps after 30 min of (no clients **AND** no running sessions). The running-sessions guard means a long build keeps its daemon alive even after Claude Code closes; idle daemons self-clean.

## Behavior matrix

| Scenario | What happens |
|---|---|
| Normal Claude Code close | MCP gets SIGTERM → kills daemon → instant cleanup. |
| Force-kill MCP (SIGKILL) | Daemon orphaned. `clients.size` drops to 0; idle timer reaps after threshold. |
| Long build, Claude Code closed | Daemon survives because `processes.some(p => p.running) === true`. After build exits, idle timer accrues; reap ~30 min later. |
| Two parallel Claude Codes | Each gets its own daemon at its own per-PID socket. No shared state. |
| Daemon crash mid-session | Existing autospawn kicks in on next request (see follow-up PR for fixes to that path). |

## Env overrides (optional)

- `TERMINALCP_SOCKET` — explicit socket path. Set automatically by `mcp-server.ts`. CLI defaults to historical singleton if unset.
- `TERMINALCP_IDLE_TIMEOUT_MS` — idle threshold before shutdown. Default `1800000` (30 min).
- `TERMINALCP_IDLE_CHECK_INTERVAL_MS` — how often the watcher runs. Default `60000` (60 s).

Last two primarily for testing — let production defaults stand.

## Smoke tests verified locally

1. **Clean SIGTERM** — spawn MCP, verify daemon at `/var/folders/.../T/terminalcp-mcp-${pid}.sock`. `kill -TERM` MCP. Within 1 s: daemon dead, socket unlinked. ✓
2. **Orphan + idle reap** — spawn MCP with `TERMINALCP_IDLE_TIMEOUT_MS=5000`. `kill -9` MCP. Daemon survives. After ~60 s (one idle check tick): daemon shuts down with `[terminalcp] idle for 60s with no clients and no running sessions — shutting down`. ✓
3. **Running session blocks idle** — spawn MCP with `TERMINALCP_IDLE_TIMEOUT_MS=1000 TERMINALCP_IDLE_CHECK_INTERVAL_MS=2000`. Start `sleep 10` session. `kill -9` MCP. At t=9s daemon alive ✓. At t=17s (sleep finished, idle checks elapsed) daemon reaped ✓.
4. Existing test suite (`tsx --test`): 70/70 pass on terminal-manager, key-parser, key-integration, cli-keys.

## Trade-offs

- CLI commands (`terminalcp ls`, etc.) operate against the historical singleton path and won't see MCP-spawned sessions. Acceptable: CLI is a debug tool; MCP is the primary interface.
- Two parallel MCPs = two daemon processes (~70 MB each) instead of one. Negligible cost for the isolation benefit.
- A long build whose Claude Code session is closed will run to completion but its output becomes inaccessible (no MCP client to query) — daemon holds it in memory for up to 30 min after exit, then dies and the output is lost. The session-log persistence PR (filed next) adds a recovery layer for this.

Happy to split into smaller commits if that helps review.