### PR TITLE
Session log persistence with two-mode capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@modelcontextprotocol/sdk": "^1.17.2",
 				"@xterm/headless": "^5.5.0",
 				"chalk": "^5.5.0",
-				"node-pty": "^1.0.0",
+				"node-pty": "1.2.0-beta.12",
 				"zod": "^3.25.76"
 			},
 			"bin": {
@@ -1598,12 +1598,6 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nan": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-			"integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-			"license": "MIT"
-		},
 		"node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1613,14 +1607,20 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
+		},
 		"node_modules/node-pty": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
-			"integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+			"integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"nan": "^2.17.0"
+				"node-addon-api": "^7.1.0"
 			}
 		},
 		"node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@modelcontextprotocol/sdk": "^1.17.2",
 		"@xterm/headless": "^5.5.0",
 		"chalk": "^5.5.0",
-		"node-pty": "^1.0.0",
+		"node-pty": "1.2.0-beta.12",
 		"zod": "^3.25.76"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,6 +301,28 @@ if (args[0] === "--mcp") {
 			console.error("Failed to start server:", err);
 			process.exit(1);
 		});
+
+		// SIGTERM is what mcp-server.ts sends; without these handlers we'd leave a stale
+		// socket file and skip clearing the idle-check timer.
+		for (const sig of ["SIGINT", "SIGTERM", "SIGQUIT"] as const) {
+			process.on(sig, () => {
+				console.error(`Received ${sig}, shutting down server...`);
+				server.shutdown().catch((err) => {
+					console.error("Shutdown error:", err);
+					process.exit(1);
+				});
+			});
+		}
+		process.on("exit", () => {
+			// Last-ditch socket cleanup if shutdown() didn't get to it.
+			if (fs.existsSync(server.serverSocketPath)) {
+				try {
+					fs.unlinkSync(server.serverSocketPath);
+				} catch {
+					// Already removed — ignore.
+				}
+			}
+		});
 	} else {
 		console.error(`Unknown command: ${args[0]}`);
 		console.error("Run 'terminalcp' without arguments to see help");

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { AttachClient } from "./attach-client.js";
 import { parseKeyInput } from "./key-parser.js";
 import { runMCPServer } from "./mcp-server.js";
 import { TerminalClient } from "./terminal-client.js";
+import { getLogDir } from "./terminal-manager.js";
 import { TerminalServer } from "./terminal-server.js";
 
 // Read version from package.json
@@ -17,6 +18,83 @@ const CLIENT_VERSION = packageJson.version;
 
 // Parse CLI arguments
 const args = process.argv.slice(2);
+
+function formatAge(seconds: number): string {
+	if (seconds < 60) return `${seconds}s ago`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+	if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+	return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes}B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+	return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+type LogEntry = { name: string; path: string; mtime: number; size: number };
+
+function readLogEntries(logDir: string): LogEntry[] {
+	if (!fs.existsSync(logDir)) return [];
+	return fs
+		.readdirSync(logDir)
+		.filter((f) => f.endsWith(".log"))
+		.map((f): LogEntry | null => {
+			const fullPath = path.join(logDir, f);
+			try {
+				const stat = fs.statSync(fullPath);
+				return { name: f, path: fullPath, mtime: stat.mtimeMs, size: stat.size };
+			} catch {
+				return null;
+			}
+		})
+		.filter((e): e is LogEntry => e !== null)
+		.sort((a, b) => b.mtime - a.mtime);
+}
+
+function handleLogsCommand(logsArgs: string[]): void {
+	const logDir = getLogDir();
+	const entries = readLogEntries(logDir);
+
+	if (logsArgs[0] === "--rm") {
+		let removed = 0;
+		for (const e of entries) {
+			try {
+				fs.unlinkSync(e.path);
+				removed++;
+			} catch {
+				// best-effort
+			}
+		}
+		console.log(removed === 0 ? "No logs to remove." : `Removed ${removed} log file(s) from ${logDir}`);
+		process.exit(0);
+	}
+
+	if (entries.length === 0) {
+		console.log(`No logs found at ${logDir}`);
+		process.exit(0);
+	}
+
+	if (logsArgs.length === 0) {
+		for (const e of entries) {
+			const ageS = Math.floor((Date.now() - e.mtime) / 1000);
+			console.log(`  ${e.name}  (${formatAge(ageS)}, ${formatSize(e.size)})`);
+		}
+		console.log(`\n${entries.length} log file(s) in ${logDir}`);
+		process.exit(0);
+	}
+
+	// Cat the newest log whose filename starts with `${name}-` (timestamp suffix).
+	const sessionName = logsArgs[0];
+	const match = entries.find((e) => e.name.startsWith(`${sessionName}-`));
+	if (!match) {
+		console.error(`No log found matching: ${sessionName}`);
+		console.error(`Run 'terminalcp logs' (no args) to see available logs.`);
+		process.exit(1);
+	}
+	process.stdout.write(fs.readFileSync(match.path, "utf-8"));
+	process.exit(0);
+}
 
 // Show help if no arguments
 if (args.length === 0) {
@@ -40,6 +118,7 @@ COMMANDS:
   term-size <id>                         Get terminal size
   version                                Show client and server versions
   kill-server                            Shutdown the terminal server
+  logs [name]                            List session logs, or cat one by name (--rm to delete all)
 
 EXAMPLES:
   # Start as MCP server for Claude Desktop
@@ -295,6 +374,8 @@ if (args[0] === "--mcp") {
 				console.error("Failed to kill server:", err.message);
 				process.exit(1);
 			});
+	} else if (args[0] === "logs") {
+		handleLogsCommand(args.slice(1));
 	} else if (args[0] === "--server") {
 		const server = new TerminalServer();
 		server.start().catch((err) => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,11 +1,77 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { Args } from "./messages.js";
 import { TerminalClient } from "./terminal-client.js";
 
+async function waitForSocket(socketPath: string, timeoutMs: number): Promise<void> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (fs.existsSync(socketPath)) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`terminalcp daemon socket did not appear at ${socketPath} within ${timeoutMs}ms`);
+}
+
 export async function runMCPServer(): Promise<void> {
-	const serverClient = new TerminalClient();
+	// Per-session isolation: each MCP instance gets its own daemon at a unique socket path
+	// keyed by this process's PID. Closes the door on cross-session interference (one Claude
+	// Code window's cleanup can no longer touch another window's daemon).
+	const socketPath = path.join(os.tmpdir(), `terminalcp-mcp-${process.pid}.sock`);
+
+	// Spawn the dedicated daemon as a non-detached child so its lifecycle is bound to ours.
+	// Three layers of cleanup: (1) explicit kill below on SIGTERM/SIGINT/exit; (2) daemon's
+	// own idle timeout (defaults to 30min, gated on no-running-sessions so long builds aren't
+	// killed); (3) socket path is per-PID, so even leaks don't collide with other sessions.
+	const daemonScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "index.js");
+	const daemon = spawn(process.execPath, [daemonScript, "--server"], {
+		env: {
+			...process.env,
+			TERMINALCP_SOCKET: socketPath,
+		},
+		// stderr inherits so daemon errors surface in the MCP server's stderr (visible in
+		// Claude Code's MCP debug logs). stdin/stdout ignored — the daemon only talks via socket.
+		stdio: ["ignore", "ignore", "inherit"],
+		detached: false,
+	});
+
+	daemon.on("error", (err) => {
+		console.error("[terminalcp] daemon spawn error:", err);
+	});
+	daemon.on("exit", (code, signal) => {
+		console.error(`[terminalcp] daemon exited (code=${code}, signal=${signal})`);
+	});
+
+	// Idempotent kill helper, registered on every shutdown signal we care about.
+	let killed = false;
+	const killDaemon = (): void => {
+		if (killed) return;
+		killed = true;
+		try {
+			daemon.kill("SIGTERM");
+		} catch {
+			// Already dead — ignore.
+		}
+	};
+	process.on("exit", killDaemon);
+
+	// Block until the daemon has bound its socket. Without this, the first TerminalClient
+	// request would race the daemon's `listen()` and trigger the auto-spawn fallback path,
+	// which would create a *second* daemon (orphaned) at the same socket path.
+	try {
+		await waitForSocket(socketPath, 5000);
+	} catch (err) {
+		console.error("[terminalcp] daemon failed to start within 5s:", err);
+		killDaemon();
+		throw err;
+	}
+
+	const serverClient = new TerminalClient(socketPath);
 
 	const server = new Server(
 		{
@@ -179,15 +245,18 @@ Note: Commands run via bash -c. Use absolute paths, not aliases.`,
 		}
 	});
 
-	// Cleanup on exit
-	process.on("SIGINT", async () => {
-		console.error("Shutting down MCP server...");
+	// Cleanup on exit — both signals tear down client and daemon before exiting.
+	const shutdown = (signal: string) => {
+		console.error(`Shutting down MCP server (${signal})...`);
 		serverClient.close();
+		killDaemon();
 		process.exit(0);
-	});
+	};
+	process.on("SIGINT", () => shutdown("SIGINT"));
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
 
 	// Start the server
 	const transport = new StdioServerTransport();
 	await server.connect(transport);
-	console.error("terminalcp MCP server running on stdio");
+	console.error(`terminalcp MCP server running on stdio (daemon socket: ${socketPath})`);
 }

--- a/src/terminal-client.ts
+++ b/src/terminal-client.ts
@@ -33,12 +33,20 @@ const CLIENT_VERSION = packageJson.version;
 
 export class TerminalClient {
 	private socket?: net.Socket;
-	private serverSocketPath = path.join(os.homedir(), ".terminalcp", "server.sock");
+	private serverSocketPath: string;
 	// biome-ignore lint/suspicious/noExplicitAny: Hard to type this without a lot of effort
 	private pendingRequests = new Map<string, { resolve: (result: any) => void; reject: (error: Error) => void }>();
 	private eventHandlers = new Map<string, (event: ServerEvent) => void>();
 	private connected = false;
 	private connectPromise?: Promise<void>;
+
+	constructor(socketPath?: string) {
+		// Explicit arg > env var > historical default. The env var lets a daemon spawned by the
+		// auto-spawn path (which inherits env from the client process) bind to the same per-instance
+		// socket the client is connecting to.
+		this.serverSocketPath =
+			socketPath || process.env.TERMINALCP_SOCKET || path.join(os.homedir(), ".terminalcp", "server.sock");
+	}
 
 	/**
 	 * Connect to the terminal server, starting it if necessary

--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -1,8 +1,40 @@
 import crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
 import * as pty from "node-pty";
+
+// Logs land at ~/.terminalcp/logs/${name}-${timestamp}.log via two paths: a one-shot exit dump
+// (MCP attached the whole time) or a tee-on-disconnect stream (MCP gone mid-session). Override
+// dir via TERMINALCP_LOG_DIR.
+export function getLogDir(): string {
+	return process.env.TERMINALCP_LOG_DIR || path.join(os.homedir(), ".terminalcp", "logs");
+}
+
+function sanitizeName(name: string): string {
+	return name.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function fileTimestamp(d: Date): string {
+	return d.toISOString().replace(/[:.]/g, "-");
+}
+
+function logPathFor(logDir: string, proc: { id: string; startedAt: Date }): string {
+	return path.join(logDir, `${sanitizeName(proc.id)}-${fileTimestamp(proc.startedAt)}.log`);
+}
+
+function closeStream(proc: ManagedTerminal): void {
+	if (!proc.logStream) return;
+	try {
+		proc.logStream.end();
+	} catch {
+		// stream already destroyed — fine
+	}
+	proc.logStream = undefined;
+}
 
 class WriteQueue {
 	private queue = Promise.resolve();
@@ -33,6 +65,12 @@ export interface ManagedTerminal {
 	ptyWriteQueue: WriteQueue;
 	running: boolean;
 	exitCode?: number;
+	/**
+	 * Active write stream for tee'd persistence. Only set after beginPersistRunningSessions has
+	 * fired (i.e., all MCP clients disconnected while this session was running). When active, every
+	 * PTY chunk is also written here. On session exit the stream is closed and the file is final.
+	 */
+	logStream?: fs.WriteStream;
 }
 
 export class TerminalManager {
@@ -86,6 +124,16 @@ export class TerminalManager {
 		proc.onData((data) => {
 			processEntry.terminalWriteQueue.enqueue(async () => {
 				processEntry.rawOutput += data;
+				// Tee path D: if persistence has been turned on for this session, mirror each PTY chunk
+				// to disk as it arrives. Wrapped so a broken stream can't take down the daemon.
+				if (processEntry.logStream) {
+					try {
+						processEntry.logStream.write(data);
+					} catch (err) {
+						console.error(`[terminalcp] log stream write error for ${id}:`, err);
+						processEntry.logStream = undefined;
+					}
+				}
 				await new Promise<void>((resolve) => {
 					terminal.write(data, () => resolve());
 				});
@@ -107,9 +155,29 @@ export class TerminalManager {
 
 			processEntry.terminalWriteQueue.enqueue(async () => {
 				processEntry.rawOutput += exitMsg;
+				// Persist the exit message into a tee'd stream too, before we close it.
+				if (processEntry.logStream) {
+					try {
+						processEntry.logStream.write(exitMsg);
+					} catch {
+						// Ignore — closing anyway.
+					}
+				}
 				await new Promise<void>((resolve) => {
 					terminal.write(exitMsg, () => resolve());
 				});
+				// Two paths for log persistence on exit:
+				//   - If a tee stream is active (D), close it cleanly.
+				//   - Otherwise (A), do a one-shot dump of the full rawOutput. This is the common
+				//     case when Claude Code stayed attached the whole time — we still want a recovery
+				//     log on disk for the user to grep/cat later.
+				if (processEntry.logStream) {
+					closeStream(processEntry);
+				} else {
+					this.writeFinalLog(processEntry).catch((err) => {
+						console.error(`[terminalcp] final log dump failed for ${id}:`, err);
+					});
+				}
 			});
 		});
 
@@ -125,8 +193,54 @@ export class TerminalManager {
 		if (!proc) {
 			throw new Error(`Process not found: ${id}`);
 		}
+		// onExit may not fire when we kill directly — close any tee stream now so the file is sealed.
+		closeStream(proc);
 		proc.process.kill();
 		this.processes.delete(id);
+	}
+
+	/**
+	 * Begin persisting all currently-running sessions to disk. Called by the daemon when its last
+	 * MCP client disconnects, so any in-flight session (e.g. a long build that's still running
+	 * after Claude Code closed) can be recovered later via `terminalcp logs`. The current rawOutput
+	 * is written as the catch-up chunk, then onData appends each new chunk going forward.
+	 */
+	beginPersistRunningSessions(): void {
+		const logDir = getLogDir();
+		try {
+			fs.mkdirSync(logDir, { recursive: true });
+		} catch (err) {
+			console.error("[terminalcp] failed to create log dir:", err);
+			return;
+		}
+
+		for (const proc of this.processes.values()) {
+			if (!proc.running || proc.logStream) continue;
+			try {
+				const logPath = logPathFor(logDir, proc);
+				const stream = fs.createWriteStream(logPath, { flags: "w" });
+				stream.on("error", (err) => {
+					console.error(`[terminalcp] log stream error for ${proc.id}:`, err);
+					proc.logStream = undefined;
+				});
+				// Catch-up: flush everything so far, then onData will append new chunks as they arrive.
+				stream.write(proc.rawOutput);
+				proc.logStream = stream;
+				console.error(`[terminalcp] persisting ${proc.id} to ${logPath}`);
+			} catch (err) {
+				console.error(`[terminalcp] failed to begin persisting ${proc.id}:`, err);
+			}
+		}
+	}
+
+	/**
+	 * One-shot final dump of a session's rawOutput. Used by the exit path when no tee stream was
+	 * ever opened — i.e. the common case where Claude Code stayed attached the whole time.
+	 */
+	private async writeFinalLog(proc: ManagedTerminal): Promise<void> {
+		const logDir = getLogDir();
+		await fs.promises.mkdir(logDir, { recursive: true });
+		await fs.promises.writeFile(logPathFor(logDir, proc), proc.rawOutput);
 	}
 
 	/**

--- a/src/terminal-server.ts
+++ b/src/terminal-server.ts
@@ -6,7 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ServerEvent, ServerMessage, ServerRequest, ServerResponse } from "./messages.js";
-import { TerminalManager } from "./terminal-manager.js";
+import { getLogDir, TerminalManager } from "./terminal-manager.js";
 
 // Read version from package.json
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -81,6 +81,11 @@ export class TerminalServer {
 				// Set socket permissions to be user-only
 				fs.chmodSync(this.serverSocketPath, 0o600);
 
+				// One-shot cleanup of stale session logs at daemon startup so disk usage stays
+				// bounded over time. Default 7 days; configurable via TERMINALCP_LOG_RETENTION_DAYS
+				// (set to 0 to keep forever).
+				this.cleanupOldLogs();
+
 				// Start idle-timeout watcher: shut down after N min of no clients AND no running sessions.
 				// The running-sessions guard means a long build keeps the daemon alive even if the
 				// client (e.g. an MCP server) disconnects — important so closing Claude Code mid-build
@@ -94,6 +99,41 @@ export class TerminalServer {
 
 	private touchActivity(): void {
 		this.lastActivityAt = Date.now();
+	}
+
+	private cleanupOldLogs(): void {
+		const logDir = getLogDir();
+		if (!fs.existsSync(logDir)) return;
+
+		const retentionDaysStr = process.env.TERMINALCP_LOG_RETENTION_DAYS;
+		const retentionDays = retentionDaysStr ? parseInt(retentionDaysStr, 10) : 7;
+		// 0 (or any non-positive / non-finite value) disables cleanup — keep logs forever.
+		if (!Number.isFinite(retentionDays) || retentionDays <= 0) return;
+
+		const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+		let removed = 0;
+		try {
+			const files = fs.readdirSync(logDir);
+			for (const f of files) {
+				if (!f.endsWith(".log")) continue;
+				const fullPath = path.join(logDir, f);
+				try {
+					const stat = fs.statSync(fullPath);
+					if (stat.mtimeMs < cutoff) {
+						fs.unlinkSync(fullPath);
+						removed++;
+					}
+				} catch {
+					// Ignore individual file errors.
+				}
+			}
+		} catch (err) {
+			console.error("[terminalcp] log cleanup error:", err);
+			return;
+		}
+		if (removed > 0) {
+			console.error(`[terminalcp] cleaned up ${removed} log file(s) older than ${retentionDays} days`);
+		}
 	}
 
 	private checkIdle(): void {
@@ -147,6 +187,13 @@ export class TerminalServer {
 			// Remove client from all session subscriptions
 			for (const subscribers of this.sessionSubscribers.values()) {
 				subscribers.delete(clientId);
+			}
+
+			// Mechanism D: when the last MCP client disconnects, kick off disk persistence for any
+			// running sessions so the user can recover their output later. Idempotent — sessions
+			// that already have a logStream are skipped inside beginPersistRunningSessions.
+			if (this.clients.size === 0) {
+				this.processManager.beginPersistRunningSessions();
 			}
 		});
 

--- a/src/terminal-server.ts
+++ b/src/terminal-server.ts
@@ -14,15 +14,37 @@ const packageJsonPath = path.join(__dirname, "..", "package.json");
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 const SERVER_VERSION = packageJson.version;
 
+// Default 30 minutes; overridable via TERMINALCP_IDLE_TIMEOUT_MS for testing or tuning.
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+// How often the idle check runs. Overridable via TERMINALCP_IDLE_CHECK_INTERVAL_MS — primarily useful
+// for tests that need to verify cleanup behavior in seconds rather than minutes.
+const DEFAULT_IDLE_CHECK_INTERVAL_MS = 60 * 1000;
+
+function positiveIntEnv(key: string, fallback: number): number {
+	const n = parseInt(process.env[key] ?? "", 10);
+	return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
 export class TerminalServer {
 	private processManager = new TerminalManager();
 	private server?: net.Server;
 	private clients = new Map<string, net.Socket>();
 	private sessionSubscribers = new Map<string, Set<string>>(); // sessionId -> Set<clientId>
-	public readonly serverSocketPath = path.join(os.homedir(), ".terminalcp", "server.sock");
+	public readonly serverSocketPath: string;
 	private clientCounter = 0;
+	private lastActivityAt = Date.now();
+	private idleCheckInterval?: NodeJS.Timeout;
+	private idleTimeoutMs: number;
+	private idleCheckIntervalMs: number;
 
 	constructor() {
+		// Allow per-instance socket path via env (set by mcp-server.ts when spawning a dedicated daemon).
+		// Falls back to the historical shared path so plain `terminalcp --server` and CLI commands still work.
+		this.serverSocketPath = process.env.TERMINALCP_SOCKET || path.join(os.homedir(), ".terminalcp", "server.sock");
+
+		this.idleTimeoutMs = positiveIntEnv("TERMINALCP_IDLE_TIMEOUT_MS", DEFAULT_IDLE_TIMEOUT_MS);
+		this.idleCheckIntervalMs = positiveIntEnv("TERMINALCP_IDLE_CHECK_INTERVAL_MS", DEFAULT_IDLE_CHECK_INTERVAL_MS);
+
 		// Ensure directory exists
 		const dir = path.dirname(this.serverSocketPath);
 		if (!fs.existsSync(dir)) {
@@ -59,15 +81,43 @@ export class TerminalServer {
 				// Set socket permissions to be user-only
 				fs.chmodSync(this.serverSocketPath, 0o600);
 
+				// Start idle-timeout watcher: shut down after N min of no clients AND no running sessions.
+				// The running-sessions guard means a long build keeps the daemon alive even if the
+				// client (e.g. an MCP server) disconnects — important so closing Claude Code mid-build
+				// doesn't kill the build.
+				this.idleCheckInterval = setInterval(() => this.checkIdle(), this.idleCheckIntervalMs);
+
 				resolve();
 			});
 		});
+	}
+
+	private touchActivity(): void {
+		this.lastActivityAt = Date.now();
+	}
+
+	private checkIdle(): void {
+		const idleMs = Date.now() - this.lastActivityAt;
+		const noClients = this.clients.size === 0;
+		const processes = this.processManager.listProcesses();
+		const noRunningSessions = !processes.some((p) => p.running);
+
+		if (noClients && noRunningSessions && idleMs >= this.idleTimeoutMs) {
+			console.error(
+				`[terminalcp] idle for ${Math.floor(idleMs / 1000)}s with no clients and no running sessions — shutting down`,
+			);
+			this.shutdown().catch((err) => {
+				console.error("Idle shutdown error:", err);
+				process.exit(0);
+			});
+		}
 	}
 
 	/**
 	 * Handle a new client connection
 	 */
 	private handleClient(socket: net.Socket): void {
+		this.touchActivity();
 		const clientId = `client-${++this.clientCounter}`;
 		this.clients.set(clientId, socket);
 
@@ -109,6 +159,7 @@ export class TerminalServer {
 	 * Handle a message from a client
 	 */
 	private async handleMessage(clientId: string, message: ServerRequest): Promise<void> {
+		this.touchActivity();
 		const { id: requestId, args } = message;
 
 		if (!requestId || !args.action) {
@@ -344,6 +395,12 @@ export class TerminalServer {
 	 */
 	async shutdown(): Promise<void> {
 		console.error("Shutting down terminal server...");
+
+		// Stop the idle-check timer so the process can exit cleanly.
+		if (this.idleCheckInterval) {
+			clearInterval(this.idleCheckInterval);
+			this.idleCheckInterval = undefined;
+		}
 
 		// Stop all processes
 		await this.processManager.stopAll();


### PR DESCRIPTION
Hey @badlogic 👋

Stacked on #5 (per-session daemon isolation) — diff includes its commits because they share infrastructure (the disconnect-detection hook). The new content for **this** PR is the third commit, `Add session log persistence with two-mode capture`.

## Problem

Per-session daemon isolation (#5) plus idle-timeout reap means a session's output lives only in daemon memory. When the daemon eventually shuts down (idle, crash, SIGKILL), that output is gone forever.

Hit this myself with a 4-minute Vercel deploy that died with the daemon — couldn't see what failed, couldn't reproduce on the next attempt because the failure was timing-dependent. No way to grep the build log post-mortem.

## Fix

Sessions now leave a recovery log on disk via two complementary write paths. Both write to `~/.terminalcp/logs/${name}-${ISO_timestamp}.log` (override dir via `TERMINALCP_LOG_DIR`):

- **A — Final-state dump on session exit.** Common case (MCP attached the whole time). When the PTY process exits, `writeFinalLog` does one `writeFile` of the full `rawOutput`. Cost: one async write per completed session.
- **B — Tee on MCP disconnect.** Recovery case (MCP closed while session is still running). When the daemon's last MCP client disconnects, `beginPersistRunningSessions` opens a `WriteStream` per running session, writes the existing `rawOutput` as a catch-up chunk, then appends each subsequent PTY chunk. On exit, the stream is closed (no double-write — A's exit handler only fires `writeFinalLog` if no `logStream` exists).

Together, every session ends up with a complete log on disk regardless of whether MCP stayed attached.

## CLI

```bash
terminalcp logs                # list newest first with age + size
terminalcp logs <session_name> # cat the newest matching log
terminalcp logs --rm           # delete all logs in the dir
```

The CLI doesn't touch the daemon — it reads files directly. Works even if every daemon is dead.

## Retention

Daemon does a one-shot cleanup at startup: any `.log` file with `mtime` older than `TERMINALCP_LOG_RETENTION_DAYS` (default 7) is unlinked. Set the env var to `0` (or any non-positive value) to keep logs forever.

## Edge cases handled

| Scenario | Behavior |
|---|---|
| Session exits, MCP attached | A writes final dump |
| Session running, MCP disconnects | B opens stream, writes catch-up + appends new chunks |
| Session stuck on prompt while MCP gone | B captures rawOutput up to the prompt; new arrivals appended |
| Session force-killed via `terminalcp stop` | `stop()` closes any active stream cleanly before killing the PTY |
| Daemon SIGKILLed mid-tee | OS releases stream FD; whatever was buffered may not flush, but everything `write()`d before the kill is on disk |
| Disk full / write error | Caught, `logStream` set to undefined, daemon continues |
| Same name run multiple times | Timestamp suffix ensures unique filenames |

## Smoke tests

1. **D-path (CLI is a disconnect-after-request client)** — `terminalcp start build1 "echo line-one; sleep 1; echo line-two; echo done"` → file appears at `~/.terminalcp/logs/build1-${ts}.log` with full content + `[Process exited with code 0]`. ✓
2. **CLI list/cat/rm** — `logs` lists with age/size, `logs build1` cats correctly, `logs nonexistent` errors helpfully, `logs --rm` removes all. ✓
3. **TTL cleanup** — placed an mtime-10d-old file in log dir, started daemon → stderr `[terminalcp] cleaned up 1 log file(s) older than 7 days`, only fresh file remained. ✓
4. **A-path (sustained MCP)** — kept MCP alive while session ran and exited → file appeared via `writeFinalLog`. ✓

## Recovery flow

```bash
terminalcp logs                         # find the session by name + age
terminalcp logs vercel-deploy           # cat its log
terminalcp logs vercel-deploy | grep -i error
```

No daemon required.