### PR TITLE
Remove unreachable direct-entry block from terminal-server.ts

### DIFF
--- a/src/terminal-server.ts
+++ b/src/terminal-server.ts
@@ -409,34 +409,3 @@ export async function startServer(): Promise<void> {
 	// Give the server a moment to start
 	await new Promise((resolve) => setTimeout(resolve, 100));
 }
-
-// If run directly, start the server
-if (import.meta.url === `file://${process.argv[1]}`) {
-	const server = new TerminalServer();
-
-	server.start().catch((err) => {
-		console.error("Failed to start server:", err);
-		process.exit(1);
-	});
-
-	// Handle shutdown signals
-	process.on("SIGINT", async () => {
-		await server.shutdown();
-	});
-	process.on("SIGTERM", async () => {
-		await server.shutdown();
-	});
-	process.on("SIGQUIT", async () => {
-		await server.shutdown();
-	});
-	process.on("exit", () => {
-		// Last-ditch cleanup on any exit
-		if (fs.existsSync(server.serverSocketPath)) {
-			try {
-				fs.unlinkSync(server.serverSocketPath);
-			} catch (_err) {
-				// Ignore
-			}
-		}
-	});
-}


### PR DESCRIPTION
Hey @badlogic 👋

Drive-by cleanup, independent of the four PRs in #4–#7. Pre-existing dead code, easy to verify.

## What

`terminal-server.ts` ends with:

```typescript
// If run directly, start the server
if (import.meta.url === `file://${process.argv[1]}`) {
  const server = new TerminalServer();
  server.start().catch(...)
  process.on("SIGINT", ...)
  process.on("SIGTERM", ...)
  process.on("SIGQUIT", ...)
  process.on("exit", ...)
}
```

That branch fires only when `terminal-server.js` is the script entry — but it never is. The package's only entry point is `dist/index.js`:

- `package.json`: `"main": "dist/index.js"`, `"bin": { "terminalcp": "dist/index.js" }`
- `index.ts`'s `--server` branch is what `mcp-server.ts` invokes via `spawn(process.execPath, [daemonScript, "--server"])` and what end users run via `terminalcp --server`
- `grep -rn "terminal-server" src/ test/ package.json` finds only module imports of `TerminalServer` / `startServer` / types — zero callers running `terminal-server.js` as the entry

`index.ts`'s `--server` branch already wires SIGINT/SIGTERM/SIGQUIT/exit handlers, so removing this block changes nothing reachable.

## Diff

`src/terminal-server.ts`: -31 lines (the `if (import.meta.url === ...)` block + its preceding blank line and comment).

## Verification

- `bun run build` — clean
- `bunx biome check .` — same 13 baseline warnings, no new issues
- `tsx --test test/{terminal-manager,key-parser,cli-keys,key-integration}.test.ts` — 70/70 pass
- Daemon spawn via `node dist/index.js --server` still works (exercised by `terminal-manager.test.ts`, which uses the manager directly via the canonical path)

Happy to add a test or do anything else if helpful. Branched directly off `main`, no dependencies on #4–#7.